### PR TITLE
Remove `/deep/` selector

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -28,46 +28,46 @@ atom-workspace {
 // Scrollbars ------------------------------------
 
 .scrollbars-visible-always {
-	/deep/ ::-webkit-scrollbar {
+	::-webkit-scrollbar {
 		width: 10px;
 		height: 10px;
 	}
 
-	/deep/ ::-webkit-scrollbar-track {
+	::-webkit-scrollbar-track {
 		background: @scrollbar-background-color;
 	}
 
-	/deep/ ::-webkit-scrollbar-thumb {
+	::-webkit-scrollbar-thumb {
 		border-radius: 5px;
 		border: 3px solid @scrollbar-background-color;
 		background: @scrollbar-color;
 		background-clip: content-box;
 	}
 
-	/deep/ ::-webkit-scrollbar-corner {
+	::-webkit-scrollbar-corner {
 		background: @scrollbar-background-color;
 	}
 
-	/deep/ ::-webkit-scrollbar-thumb:vertical:active {
+	::-webkit-scrollbar-thumb:vertical:active {
 		border-radius: 0;
 		border-left-width: 0;
 		border-right-width: 0;
 	}
 
-	/deep/ ::-webkit-scrollbar-thumb:horizontal:active {
+	::-webkit-scrollbar-thumb:horizontal:active {
 		border-radius: 0;
 		border-top-width: 0;
 		border-bottom-width: 0;
 	}
 
 	atom-text-editor {
-		/deep/ ::-webkit-scrollbar-track {
+		::-webkit-scrollbar-track {
 			background: @scrollbar-background-color-editor;
 		}
-		/deep/ ::-webkit-scrollbar-corner {
+		::-webkit-scrollbar-corner {
 			background: @scrollbar-background-color-editor;
 		}
-		/deep/ ::-webkit-scrollbar-thumb {
+	 ::-webkit-scrollbar-thumb {
 			border-color: @scrollbar-background-color-editor;
 			background: @scrollbar-color-editor;
 		}


### PR DESCRIPTION
The `/deep/` selector is no longer needed to properly style the scrollbar, and usage of this outdated, no longer supported selector causes no styling to be applied, and the scrollbar then becomes styled by the user agent instead. 

By removing it's usage this package can function as expected.

To see the investigation into this issue and it's impact [`pulsar-edit/pulsar#442`](https://github.com/pulsar-edit/pulsar/issues/442)

---

While I'm aware this package was originally made and published for Atom, it has been migrated to Pulsar. Which is the Community-led fork of Atom. If you do accept this change, and add it to the package, it is highly encouraged to update it as well on the Pulsar Package Registry. Please feel free to chat with me if any help is needed in doing so. 

Since it's rather easy if Pulsar is installed by using `pulsar -p publish minor` similar to how the old APM command worked.

Otherwise if you'd like to avoid having to install Pulsar just to give this package an update, it's also possible to simply publish a new tag on this GitHub repo, (after updating the `package.json` of course, so it's version matches that of a new tag) then you can just make a POST request to Pulsar with your Pulsar user account API key. So it's possibly to update without ever downloading Pulsar if you'd not like to.

Again feel free to communicate further with me or anyone on the Pulsar team for help. Thanks a ton!